### PR TITLE
Scroll height error

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -78,6 +78,7 @@ export class AppComponent implements OnInit{
   @HostListener('window:scroll', ['$event'])
   onScroll(event) {
     let height = window.scrollY;
+    console.log(height);
     if(height > 400) this.firstPageInView = true;
     else this.firstPageInView = false;
 
@@ -85,7 +86,7 @@ export class AppComponent implements OnInit{
     else if(height > 800 && this.mobile) this.secondPageInView = true;
     else this.secondPageInView = false;
 
-    if(height >= 2300 && !this.mobile) this.thirdPageInView = true;
+    if(height >= 2000 && !this.mobile) this.thirdPageInView = true;
     else if(height >= 1400 && this.mobile) this.thirdPageInView = true;
     else this.thirdPageInView = false;
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -78,7 +78,6 @@ export class AppComponent implements OnInit{
   @HostListener('window:scroll', ['$event'])
   onScroll(event) {
     let height = window.scrollY;
-    console.log(height);
     if(height > 400) this.firstPageInView = true;
     else this.firstPageInView = false;
 


### PR DESCRIPTION
Error was with scroll height method in typescript. Hence why the error persisted in any browser on Mac. This needs to be refactored as onscroll methods are too wasteful, perhaps a method based on the height of particular divs. Also on Safari the scroll snapping is not working, this must be investigated.